### PR TITLE
Bump micropython version from 1.15 to 1.19.1

### DIFF
--- a/package/micropython/micropython.hash
+++ b/package/micropython/micropython.hash
@@ -1,3 +1,3 @@
 #locally computed
-sha256  852bac39b00bc374ee2ac19198574be17e3b9f47cdf3e2088bebb7e8490aa626  micropython-1.15.tar.gz
+sha256  c980ad7e742491df0dc10db2958137dbbf9aa7a8009e102fc75f4c0cac2d6b5e  micropython-1.19.1.tar.gz
 sha256  9c6089e26c8638a0645bcb0db2c85051f82de8022dcd07fb22baa0c5f9362085  LICENSE

--- a/package/micropython/micropython.mk
+++ b/package/micropython/micropython.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-MICROPYTHON_VERSION = 1.15
+MICROPYTHON_VERSION = 1.19.1
 MICROPYTHON_SITE = $(call github,micropython,micropython,v$(MICROPYTHON_VERSION))
 MICROPYTHON_LICENSE = MIT
 MICROPYTHON_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This PR bump micropython version from v1.15 to v1.19.1.
(https://github.com/micropython/micropython/releases)

The size of the `/usr/bin/micropython` file has increased by 8 KB.
(305,952 bytes (≈ 299 KB) to 314,488 bytes (≈ 307 KB))

I think this PR will address the https://github.com/fnuecke/oc2/issues/217 issue.

I tested it with the `sedna-1.18.2-forge-1.0.13.jar` file and it works as expected.